### PR TITLE
Handle long-running probe with background tasks

### DIFF
--- a/backend/routes/probe_routes.py
+++ b/backend/routes/probe_routes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter
 from pathlib import Path
 import json
+import threading
+import uuid
 
 from modules.feature_extractor import FeatureExtractor
 
@@ -22,19 +24,19 @@ SMART_PROBE_PAYLOADS = [
 
 SKIP_PARAMS = {"password", "csrf", "authenticity_token"}
 
-@router.post("/probe")
-def probe_endpoints():
-    if not CRAWL_RESULT_FILE.exists():
-        return {"error": "Crawl result file not found."}
+PROBE_JOBS = {}
 
+
+def _run_probe(job_id: str) -> None:
     with open(CRAWL_RESULT_FILE, "r", encoding="utf-8") as f:
         raw_data = json.load(f)
         endpoints = raw_data.get("endpoints", []) + raw_data.get("captured_requests", [])
 
     probed_results = []
     seen = set()
+    total = len(endpoints) if endpoints else 1
 
-    for ep in endpoints:
+    for idx, ep in enumerate(endpoints, start=1):
         url = ep.get("url")
         params = ep.get("params", [])
         method = ep.get("method", "GET")
@@ -57,7 +59,6 @@ def probe_endpoints():
                     "probe_payload": payload
                 }
 
-                # If reflected, extract metadata for logging
                 if features:
                     result["reflection_type"] = {
                         1: "raw",
@@ -73,10 +74,37 @@ def probe_endpoints():
 
                 probed_results.append(result)
                 if features:
-                    break  # stop after first success
+                    break
+
+        PROBE_JOBS[job_id]["progress"] = int(idx / total * 100)
 
     PROBED_OUTPUT_FILE.parent.mkdir(parents=True, exist_ok=True)
     with open(PROBED_OUTPUT_FILE, "w", encoding="utf-8") as f:
         json.dump(probed_results, f, indent=2)
 
-    return {"status": "done", "probed_count": len(probed_results)}
+    PROBE_JOBS[job_id]["status"] = "completed"
+    PROBE_JOBS[job_id]["result"] = {
+        "status": "done",
+        "probed_count": len(probed_results)
+    }
+
+
+@router.post("/probe")
+def probe_endpoints():
+    if not CRAWL_RESULT_FILE.exists():
+        return {"error": "Crawl result file not found."}
+
+    job_id = str(uuid.uuid4())
+    PROBE_JOBS[job_id] = {"status": "running", "progress": 0}
+    thread = threading.Thread(target=_run_probe, args=(job_id,), daemon=True)
+    thread.start()
+    return {"task_id": job_id}
+
+
+@router.get("/probe/status/{job_id}")
+def probe_status(job_id: str):
+    job = PROBE_JOBS.get(job_id)
+    if not job:
+        return {"error": "Invalid task ID"}
+    return job
+

--- a/frontend/src/app/api/api.js
+++ b/frontend/src/app/api/api.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 // Axios instance with baseURL
 const api = axios.create({
   baseURL: 'http://localhost:8000/api',  // Adjust if needed
-  timeout: 50000,
+  timeout: 0, // Disable timeout to allow long-running requests
 });
 
 // Global Response Interceptor
@@ -113,4 +113,26 @@ export const exploitTarget = (tool, endpoint_url, options = {}) => {
 
 export const getReport = () => {
   return api.get('/report', { responseType: 'blob' });
+};
+
+// === Probe API ===
+
+export const startProbe = async () => {
+  try {
+    const res = await api.post('/probe');
+    return res.data;
+  } catch (err) {
+    console.error('Start Probe failed:', err);
+    throw err;
+  }
+};
+
+export const getProbeStatus = async (taskId) => {
+  try {
+    const res = await api.get(`/probe/status/${taskId}`);
+    return res.data;
+  } catch (err) {
+    console.error('Get Probe Status failed:', err);
+    throw err;
+  }
 };


### PR DESCRIPTION
## Summary
- Disable Axios timeout so the frontend can wait for long-running requests
- Run probe in background thread and expose job status endpoint
- Add frontend helpers to start a probe and poll its status

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e34c710a483288170c4d13142d5d6